### PR TITLE
CTP-4173: encapsulate $enrolleduserids in feedback_tracker::get_module_submission()

### DIFF
--- a/block_my_feedback.php
+++ b/block_my_feedback.php
@@ -230,9 +230,6 @@ class block_my_feedback extends block_base {
             $mods = $modinfo->get_cms();
             $cmids = array_column($mods, 'id');
 
-            $enrolledusers = get_enrolled_users(context_course::instance($course->id));
-            $enrolleduserids = array_map(fn($user) => $user->id, $enrolledusers);
-
             // Loop through assessments for this course.
             foreach ($summatives as $summative) {
 
@@ -269,7 +266,7 @@ class block_my_feedback extends block_base {
                         $turnitin = clone $assess;
                         $turnitin->partid = $turnitinpart->id;
                         // Check mod has duedate and require marking.
-                        if (self::add_mod_data($mod, $turnitin, $enrolleduserids)) {
+                        if (self::add_mod_data($mod, $turnitin)) {
                             $turnitin->name = $mod->name . ' ' . $turnitinpart->partname;
                             $marking[] = $turnitin;
                         }
@@ -277,7 +274,7 @@ class block_my_feedback extends block_base {
                 } else {
                     // Check mod has duedate and require marking.
                     if (\report_feedback_tracker\local\helper::is_supported_module($mod->modname) &&
-                            self::add_mod_data($mod, $assess, $enrolleduserids)) {
+                            self::add_mod_data($mod, $assess)) {
                         $marking[] = $assess;
                     }
                 }
@@ -300,10 +297,9 @@ class block_my_feedback extends block_base {
      *
      * @param cm_info $mod
      * @param stdClass $assess
-     * @param array $enrolleduserids
      * @return bool
      */
-    public static function add_mod_data(cm_info $mod, stdClass $assess, array $enrolleduserids): bool {
+    public static function add_mod_data(cm_info $mod, stdClass $assess): bool {
         global $CFG, $DB;
 
         // Get duedate.
@@ -319,8 +315,8 @@ class block_my_feedback extends block_base {
         }
 
         // Return null if no duedate or no marking.
-        $submissions = feedback_tracker::get_module_submissions($mod, $enrolleduserids);
-        if (!$assess->requiremarking = feedback_tracker::count_missing_grades($mod, $submissions)) {
+        $submitterids = feedback_tracker::get_module_submitterids($mod);
+        if (!$assess->requiremarking = feedback_tracker::count_missing_grades($mod, $submitterids)) {
             return false;
         }
 


### PR DESCRIPTION
Following the suggested code from @stuartlamour , thanks!

Please review/approve in sync with the related PR for the Feedback Tracker report (https://github.com/ucl-isd/moodle-report_feedback_tracker/pull/98).