### PR TITLE
CTP-4805: getting gradeitem ID for feedback_tracker::count_missing_grades()

### DIFF
--- a/block_my_feedback.php
+++ b/block_my_feedback.php
@@ -309,7 +309,7 @@ class block_my_feedback extends block_base {
             $duedate = feedback_tracker::get_duedate($mod);
         }
 
-        // Check mod has due date, and due date is in range.
+        // Check that mod has a due date, and the due date is in range.
         if (($duedate === 0) || !self::duedate_in_range($duedate)) {
             return false;
         }
@@ -323,7 +323,7 @@ class block_my_feedback extends block_base {
         ];
         $gradeitemid = $DB->get_field('grade_items', 'id', $params);
 
-        // Return null if no duedate or no missing markings.
+        // Check that mod has missing markings.
         $submitterids = feedback_tracker::get_module_submitterids($mod);
         if (!$assess->requiremarking = feedback_tracker::count_missing_grades($mod, $submitterids, $gradeitemid)) {
             return false;

--- a/block_my_feedback.php
+++ b/block_my_feedback.php
@@ -314,9 +314,18 @@ class block_my_feedback extends block_base {
             return false;
         }
 
-        // Return null if no duedate or no marking.
+        // Get the grade item ID.
+        $params = [
+            'itemtype' => 'mod',
+            'itemnumber' => 0,
+            'itemmodule' => $mod->modname,
+            'iteminstance' => $mod->instance,
+        ];
+        $gradeitemid = $DB->get_field('grade_items', 'id', $params);
+
+        // Return null if no duedate or no missing markings.
         $submitterids = feedback_tracker::get_module_submitterids($mod);
-        if (!$assess->requiremarking = feedback_tracker::count_missing_grades($mod, $submitterids)) {
+        if (!$assess->requiremarking = feedback_tracker::count_missing_grades($mod, $submitterids, $gradeitemid)) {
             return false;
         }
 


### PR DESCRIPTION
Now getting the grade item ID needed for feedback_tracker::count_missing_grades() here, which makes everything more logical. 
Please approve together with https://github.com/ucl-isd/moodle-report_feedback_tracker/pull/111
