### PR TITLE
CTP-4828: improved external call

### DIFF
--- a/block_my_feedback.php
+++ b/block_my_feedback.php
@@ -324,7 +324,7 @@ class block_my_feedback extends block_base {
         $gradeitemid = $DB->get_field('grade_items', 'id', $params);
 
         // Check that mod has missing markings.
-        $submitterids = feedback_tracker::get_module_submitterids($mod);
+        $submitterids = array_column(feedback_tracker::get_module_submissions($mod), 'userid');
         if (!$assess->requiremarking = feedback_tracker::count_missing_grades($mod, $submitterids, $gradeitemid)) {
             return false;
         }


### PR DESCRIPTION
feedback_tracker::get_module_submitterids() has been removed now, so we need to update how we get the submitters here as well.