### PR TITLE
CTP-4656: using switch to only return missing marks for given marker for coursework assessments

### DIFF
--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -74,7 +74,6 @@ jobs:
       - name: Install moodle-plugin-ci
         run: |
           moodle-plugin-ci add-plugin -b main --clone https://github.com/ucl-isd/moodle-local_assess_type.git
-          moodle-plugin-ci add-plugin -b main --clone https://github.com/ucl-isd/moodle-report_feedback_tracker.git
           moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
         env:
           DB: ${{ matrix.database }}

--- a/.github/workflows/moodle-ci.yml
+++ b/.github/workflows/moodle-ci.yml
@@ -74,6 +74,7 @@ jobs:
       - name: Install moodle-plugin-ci
         run: |
           moodle-plugin-ci add-plugin -b main --clone https://github.com/ucl-isd/moodle-local_assess_type.git
+          moodle-plugin-ci add-plugin -b main --clone https://github.com/ucl-isd/moodle-report_feedback_tracker.git
           moodle-plugin-ci install --plugin ./plugin --db-host=127.0.0.1
         env:
           DB: ${{ matrix.database }}

--- a/block_my_feedback.php
+++ b/block_my_feedback.php
@@ -325,7 +325,8 @@ class block_my_feedback extends block_base {
 
         // Check that mod has missing markings.
         $submitterids = array_column(feedback_tracker::get_module_submissions($mod), 'userid');
-        if (!$assess->requiremarking = feedback_tracker::count_missing_grades($mod, $submitterids, $gradeitemid, true)) {
+        $assess->requiremarking = feedback_tracker::count_missing_grades($mod, $submitterids, $gradeitemid, true);
+        if ($assess->requiremarking === 0) {
             return false;
         }
 
@@ -456,7 +457,9 @@ class block_my_feedback extends block_base {
         // Limit to last 3 months.
         $since = strtotime('-3 month');
         // Construct the IN clause.
-        list($insql, $params) = $DB->get_in_or_equal(['assign', 'quiz', 'turnitintooltwo'], SQL_PARAMS_NAMED);
+        // Get supported module types from feedback_tracker.
+        $supported = \report_feedback_tracker\local\helper::get_supported_types();
+        list($insql, $params) = $DB->get_in_or_equal($supported, SQL_PARAMS_NAMED);
 
         // Add other params.
         $params['userid'] = $user->id;

--- a/block_my_feedback.php
+++ b/block_my_feedback.php
@@ -254,7 +254,7 @@ class block_my_feedback extends block_base {
                 $assess->name = $mod->name;
                 $assess->coursename = $course->fullname;
                 $assess->url = new moodle_url('/mod/'. $mod->modname. '/view.php', ['id' => $cmid]);
-                // TODO - is this expensive?
+                // Todo - is this expensive?
                 // If so should we only do it once we know we want to display it?
                 $assess->icon = course_summary_exporter::get_course_image($course);
 
@@ -300,7 +300,7 @@ class block_my_feedback extends block_base {
      * @return bool
      */
     public static function add_mod_data(cm_info $mod, stdClass $assess): bool {
-        global $CFG, $DB;
+        global $DB;
 
         // Get duedate.
         if ($mod->modname === 'turnitintooltwo') {
@@ -325,7 +325,7 @@ class block_my_feedback extends block_base {
 
         // Check that mod has missing markings.
         $submitterids = array_column(feedback_tracker::get_module_submissions($mod), 'userid');
-        if (!$assess->requiremarking = feedback_tracker::count_missing_grades($mod, $submitterids, $gradeitemid)) {
+        if (!$assess->requiremarking = feedback_tracker::count_missing_grades($mod, $submitterids, $gradeitemid, true)) {
             return false;
         }
 

--- a/block_my_feedback.php
+++ b/block_my_feedback.php
@@ -18,6 +18,7 @@ use core_course\external\course_summary_exporter;
 use local_assess_type\assess_type; // UCL plugin.
 use mod_quiz\question\display_options;
 use report_feedback_tracker\local\admin as feedback_tracker; // UCL plugin.
+use report_feedback_tracker\local\helper as feedback_tracker_helper; // UCL plugin.
 
 /**
  * Block definition class for the block_my_feedback plugin.
@@ -261,7 +262,7 @@ class block_my_feedback extends block_base {
                 // Turnitin.
                 if ($assess->modname === 'turnitintooltwo') {
                     // Fetch parts.
-                    $turnitinparts = \report_feedback_tracker\local\helper::get_turnitin_parts($mod->instance);
+                    $turnitinparts = feedback_tracker_helper::get_turnitin_parts($mod->instance);
                     foreach ($turnitinparts as $turnitinpart) {
                         $turnitin = clone $assess;
                         $turnitin->partid = $turnitinpart->id;
@@ -273,7 +274,7 @@ class block_my_feedback extends block_base {
                     }
                 } else {
                     // Check mod has duedate and require marking.
-                    if (\report_feedback_tracker\local\helper::is_supported_module($mod->modname) &&
+                    if (feedback_tracker_helper::is_supported_module($mod->modname) &&
                             self::add_mod_data($mod, $assess)) {
                         $marking[] = $assess;
                     }
@@ -514,6 +515,7 @@ class block_my_feedback extends block_base {
     public function get_supported_types(): array {
 
         $supported = [];
+
         $types = [
             'assign',
             'coursework',
@@ -526,9 +528,9 @@ class block_my_feedback extends block_base {
 
         // Only include optional module types if they are installed.
         $installed = \core_component::get_plugin_list('mod');
-
         foreach ($types as $modname) {
-            if (array_key_exists($modname, $installed) && \report_feedback_tracker\local\helper::is_supported_module($modname)) {
+            if (array_key_exists($modname, $installed)
+                    && (PHPUNIT_TEST || feedback_tracker_helper::is_supported_module($modname))) {
                 $supported[] = $modname;
             }
         }

--- a/block_my_feedback.php
+++ b/block_my_feedback.php
@@ -512,30 +512,27 @@ class block_my_feedback extends block_base {
      * @return array
      */
     public function get_supported_types(): array {
+
         $supported = [];
         $types = [
             'assign',
+            'coursework',
             'lesson',
             'manual',
             'quiz',
+            'turnitintooltwo',
             'workshop',
         ];
 
-        $pluginlist = \core_component::get_plugin_list('mod');
-
         // Only include optional module types if they are installed.
-        if (array_key_exists('coursework', $pluginlist)) {
-            $types[] = 'coursework';
-        }
-        if (array_key_exists('turnitintooltwo', $pluginlist)) {
-            $types[] = 'turnitintooltwo';
-        }
+        $installed = \core_component::get_plugin_list('mod');
 
         foreach ($types as $modname) {
-            if (\report_feedback_tracker\local\helper::is_supported_module($modname)) {
+            if (array_key_exists($modname, $installed) && \report_feedback_tracker\local\helper::is_supported_module($modname)) {
                 $supported[] = $modname;
             }
         }
+
         return $supported;
     }
 

--- a/block_my_feedback.php
+++ b/block_my_feedback.php
@@ -457,8 +457,8 @@ class block_my_feedback extends block_base {
         // Limit to last 3 months.
         $since = strtotime('-3 month');
         // Construct the IN clause.
-        // Get supported module types from feedback_tracker.
-        $supported = \report_feedback_tracker\local\helper::get_supported_types();
+        // Get supported module types.
+        $supported = $this->get_supported_types();
         list($insql, $params) = $DB->get_in_or_equal($supported, SQL_PARAMS_NAMED);
 
         // Add other params.
@@ -504,6 +504,39 @@ class block_my_feedback extends block_base {
                 ORDER BY gg.timemodified DESC";
 
         return $DB->get_records_sql($sql, $params);
+    }
+
+    /**
+     * Return an array of supported module types.
+     *
+     * @return array
+     */
+    public function get_supported_types(): array {
+        $supported = [];
+        $types = [
+            'assign',
+            'lesson',
+            'manual',
+            'quiz',
+            'workshop',
+        ];
+
+        $pluginlist = \core_component::get_plugin_list('mod');
+
+        // Only include optional module types if they are installed.
+        if (array_key_exists('coursework', $pluginlist)) {
+            $types[] = 'coursework';
+        }
+        if (array_key_exists('turnitintooltwo', $pluginlist)) {
+            $types[] = 'turnitintooltwo';
+        }
+
+        foreach ($types as $modname) {
+            if (\report_feedback_tracker\local\helper::is_supported_module($modname)) {
+                $supported[] = $modname;
+            }
+        }
+        return $supported;
     }
 
     /**


### PR DESCRIPTION
Making use of the newly introduced boolean switch in feedback_tracker::count_missing_grades() which allows to return only coursework missing grades for the current user as assessor.
