### PR TITLE
CTP-6299: If grader cannot be found show course image instead of grader picture

### DIFF
--- a/block_my_feedback.php
+++ b/block_my_feedback.php
@@ -412,20 +412,16 @@ class block_my_feedback extends block_base {
             $feedback->url = new moodle_url('/mod/' . $f->modname . '/view.php', ['id' => $f->cmid]);
             $feedback->coursename = $course->fullname;
 
-            if ($feedbackdata->hidegrader) {
-                $feedback->icon = course_summary_exporter::get_course_image($course);
+            if (!$feedbackdata->hidegrader && ($grader = core_user::get_user($f->grader))) {
+                // If a grader can be found return tutor name and picture.
+                $userpicture = new user_picture($grader);
+                $userpicture->size = 100;
+                $icon = $userpicture->get_url($this->page)->out(false);
+                $feedback->tutorname = fullname($grader);
+                $feedback->icon = $icon;
             } else {
-                $grader = core_user::get_user($f->grader);
-                // If a grader can be found return tutor name and picture, otherwise return course image.
-                if ($grader && isset($grader->id)) {
-                    $userpicture = new user_picture($grader);
-                    $userpicture->size = 100;
-                    $icon = $userpicture->get_url($this->page)->out(false);
-                    $feedback->tutorname = fullname($grader);
-                    $feedback->icon = $icon;
-                } else {
-                    $feedback->icon = course_summary_exporter::get_course_image($course);
-                }
+                // Otherwise return course image.
+                $feedback->icon = course_summary_exporter::get_course_image($course);
             }
 
             $feedbacks[] = $feedback;

--- a/block_my_feedback.php
+++ b/block_my_feedback.php
@@ -416,11 +416,16 @@ class block_my_feedback extends block_base {
                 $feedback->icon = course_summary_exporter::get_course_image($course);
             } else {
                 $grader = core_user::get_user($f->grader);
-                $userpicture = new user_picture($grader);
-                $userpicture->size = 100;
-                $icon = $userpicture->get_url($this->page)->out(false);
-                $feedback->tutorname = fullname($grader);
-                $feedback->icon = $icon;
+                // If a grader can be found return tutor name and picture, otherwise return course image.
+                if ($grader && isset($grader->id)) {
+                    $userpicture = new user_picture($grader);
+                    $userpicture->size = 100;
+                    $icon = $userpicture->get_url($this->page)->out(false);
+                    $feedback->tutorname = fullname($grader);
+                    $feedback->icon = $icon;
+                } else {
+                    $feedback->icon = course_summary_exporter::get_course_image($course);
+                }
             }
 
             $feedbacks[] = $feedback;

--- a/tests/my_feedback_test.php
+++ b/tests/my_feedback_test.php
@@ -372,4 +372,44 @@ final class my_feedback_test extends advanced_testcase {
             $this->assertCount(1, $feedback, 'Returning only 1 visible recent submission for student 2.');
         }
     }
+
+    /**
+     * Assert that feedback falls back to the course image when the grader user cannot be loaded.
+     *
+     * @return void
+     * @covers ::fetch_feedback
+     */
+    public function test_fetch_feedback_with_missing_grader_uses_course_image(): void {
+        global $DB;
+
+        $assignsubmission = $DB->get_record_sql(
+            "SELECT gg.id, gi.itemname
+               FROM {grade_grades} gg
+               JOIN {grade_items} gi ON gi.id = gg.itemid
+              WHERE gg.userid = :userid
+                AND gi.itemmodule = :itemmodule
+                AND gi.itemname = :itemname",
+            [
+                'userid' => $this->student1->id,
+                'itemmodule' => 'assign',
+                'itemname' => 'Grade assign item 1',
+            ],
+            MUST_EXIST
+        );
+
+        $DB->set_field('grade_grades', 'usermodified', null, ['id' => $assignsubmission->id]);
+
+        $feedback = $this->block->fetch_feedback($this->student1);
+
+        $this->assertNotNull($feedback);
+
+        $assignfeedback = array_values(array_filter($feedback, fn($item) => $item->name === $assignsubmission->itemname));
+        $this->assertCount(1, $assignfeedback, 'The assignment feedback item should still be returned.');
+
+        $assignfeedback = reset($assignfeedback);
+        $expectedicon = \core_course\external\course_summary_exporter::get_course_image($this->course);
+
+        $this->assertSame($expectedicon, $assignfeedback->icon);
+        $this->assertObjectNotHasProperty('tutorname', $assignfeedback);
+    }
 }


### PR DESCRIPTION
add regression test for missing grader fallback.

This was the issue:
• at least one feedback row has a grader value (gg.usermodified) that does not resolve to a real Moodle user object at render time
• the code assumes that lookup always succeeds
• there is no fallback/guard before building the picture

The fix will check for a user object before trying to get a user picture, and falls back to a course image otherwise.